### PR TITLE
chore: run Next.js build only

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "main": "index.js",
   "scripts": {
     "dev": "concurrently \"node auth/server.js\" \"next dev\"",
-    "build": "concurrently \"node auth/server.js\" \"next build\"",
+    "build": "next build",
     "start": "concurrently \"node auth/server.js\" \"next start\"",
-    "lint": "next"
+    "lint": "next",
+    "server": "node auth/server.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- simplify build script to use only Next.js build
- add standalone auth server script

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(started Next.js server; terminated)*
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c0cc3e388324862f7e4ace25dfd4